### PR TITLE
Unify Transaction type across Signer and RPCConnector

### DIFF
--- a/examples/deploybytecode/source/app.d
+++ b/examples/deploybytecode/source/app.d
@@ -26,7 +26,7 @@ void main()
         chainid: chainid,
     };
 
-    const txHash = conn.sendTransaction(tx);
+    const txHash = conn.sendTransaction(Transaction(tx));
     const receipt = conn.waitForTransactionReceipt(txHash);
     const contractAddress = receipt.contractAddress;
     assert(!contractAddress.isNull);

--- a/source/deth/signer.d
+++ b/source/deth/signer.d
@@ -34,39 +34,7 @@ class Signer
     /// Params:
     ///   tx =  tx to sign
     /// Returns: rlp encoded signed transaction
-    bytes signTransaction(Transaction tx) @safe
-    {
-        return tx.match!(
-            (const LegacyTransaction legacyTx) => signTransaction(legacyTx),
-            (const EIP2930Transaction eip2930Tx) => signTransaction(eip2930Tx),
-            (const EIP1559Transaction eip1559Tx) => signTransaction(eip1559Tx),
-        );
-    }
-
-    ///
-    bytes signTransaction(const EIP2930Transaction tx) @trusted pure
-    {
-        bytes rlpTx = tx.serializeToRLP();
-        debug logf("Rlp encoded tx %s", rlpTx.toHexString.ox);
-
-        // the secp256k1 sign function calls keccak256() internally.
-        auto signature = keypair.sign(rlpTx);
-        return tx.serializeToSignedRLP(signature);
-    }
-
-    ///
-    bytes signTransaction(const EIP1559Transaction tx) @trusted pure
-    {
-        bytes rlpTx = tx.serializeToRLP();
-        debug logf("Rlp encoded tx %s", rlpTx.toHexString.ox);
-
-        // the secp256k1 sign function calls keccak256() internally.
-        auto signature = keypair.sign(rlpTx);
-        return tx.serializeToSignedRLP(signature);
-    }
-
-    ///
-    bytes signTransaction(const LegacyTransaction tx) @safe pure
+    bytes signTransaction(const Transaction tx) @trusted
     {
         bytes rlpTx = tx.serializeToRLP();
         debug logf("Rlp encoded tx %s", rlpTx.toHexString.ox);


### PR DESCRIPTION
- Add helper functions for Transaction (SumType): getFrom, getTo, serializeToRLP, serializeToSignedRLP
- Signer.signTransaction now only accepts Transaction type
- RPCConnector.sendRawTransaction, sendTransaction, estimateGas now only accept Transaction type
- Callers must wrap concrete types with Transaction(tx)